### PR TITLE
Added files for cosmetic armor

### DIFF
--- a/src/main/resources/data/curios/tags/items/cosmetic_helmet.json
+++ b/src/main/resources/data/curios/tags/items/cosmetic_helmet.json
@@ -1,0 +1,6 @@
+{
+    "replace": false,
+    "values": [
+        "#fabric:helmet"
+    ]
+}

--- a/src/main/resources/data/fabric/tags/items/helmets.json
+++ b/src/main/resources/data/fabric/tags/items/helmets.json
@@ -1,0 +1,8 @@
+{
+    "replace": false,
+    "values": [
+        "desolation:mask",
+        "desolation:goggles",
+        "desolation:mask_and_goggles"
+    ]
+}


### PR DESCRIPTION
This may or may not be very useful as Curios is no longer being updated for Fabric for 1.17, but someone mentioned that they were trying to set up Cosmetic Armor with your mod and I realised that there were no tags for your mod. I did not test as I could not get GitHub to download the project properly for some reason, but it should work just fine. Thanks for a great mod! :)